### PR TITLE
Improve scalability of `thread_squad` with tree barrier

### DIFF
--- a/include/sysmakeshift/detail/thread_squad.hpp
+++ b/include/sysmakeshift/detail/thread_squad.hpp
@@ -11,18 +11,16 @@ namespace sysmakeshift {
 namespace detail {
 
 
-struct thread_squad_thread;
-
 struct thread_squad_impl_base
 {
-    int numThreads_;
+    int numThreads;
 };
 struct thread_squad_impl;
 
 struct thread_squad_impl_deleter
 {
     void
-    operator ()(thread_squad_impl_base* impl);
+    operator ()(thread_squad_impl_base* base);
 };
 
 using thread_squad_handle = std::unique_ptr<detail::thread_squad_impl_base, thread_squad_impl_deleter>;

--- a/include/sysmakeshift/thread_squad.hpp
+++ b/include/sysmakeshift/thread_squad.hpp
@@ -3,10 +3,7 @@
 #define INCLUDED_SYSMAKESHIFT_THREAD_SQUAD_HPP_
 
 
-#include <thread>
-#include <future>
-#include <utility>    // for move(), forward<>()
-#include <memory>     // for unique_ptr<>
+#include <utility>    // for move()
 #include <functional> // for function<>
 
 #include <gsl-lite/gsl-lite.hpp> // for span<>, not_null<>, ssize(), gsl_NODISCARD
@@ -115,8 +112,8 @@ private:
 
     static detail::thread_squad_handle
     create(thread_squad::params p);
-    
-    std::future<void>
+
+    void
     do_run(std::function<void(task_context)> task, int concurrency, bool join);
 
 public:
@@ -156,7 +153,7 @@ public:
         gsl_Expects(action);
         gsl_Expects(concurrency >= 0 && concurrency <= handle_->numThreads_);
 
-        do_run(std::move(action), concurrency, false).wait();
+        do_run(std::move(action), concurrency, false);
     }
 
         //
@@ -173,43 +170,7 @@ public:
         gsl_Expects(action);
         gsl_Expects(concurrency >= 0 && concurrency <= handle_->numThreads_);
 
-        do_run(std::move(action), concurrency, true).wait();
-    }
-
-        //
-        // Runs the given action on `concurrency` threads and returns a `std::future<void>` which represents the completion state
-        // of the tasks.
-        //ᅟ
-        // `concurrency == 0` indicates that the maximum concurrency level should be used, i.e. the task is run on all threads in
-        // the thread squad. `concurrency` must not exceed the number of threads in the thread squad.
-        // The thread squad makes a dedicated copy of `action` for every participating thread and invokes it with an appropriate
-        // task context. If `action()` throws an exception, `std::terminate()` is called.
-        //
-    gsl_NODISCARD std::future<void>
-    run_async(std::function<void(task_context)> action, int concurrency = 0) &
-    {
-        gsl_Expects(action);
-        gsl_Expects(concurrency >= 0 && concurrency <= handle_->numThreads_);
-
-        return do_run(std::move(action), concurrency, false);
-    }
-
-        //
-        // Runs the given action on `concurrency` threads and returns a `std::future<void>` which represents the completion state
-        // of the tasks.
-        //ᅟ
-        // `concurrency == 0` indicates that the maximum concurrency level should be used, i.e. the task is run on all threads in
-        // the thread squad. `concurrency` must not exceed the number of threads in the thread squad.
-        // The thread squad makes a dedicated copy of `action` for every participating thread and invokes it with an appropriate
-        // task context. If `action()` throws an exception, `std::terminate()` is called.
-        //
-    gsl_NODISCARD std::future<void>
-    run_async(std::function<void(task_context)> action, int concurrency = 0) &&
-    {
-        gsl_Expects(action);
-        gsl_Expects(concurrency >= 0 && concurrency <= handle_->numThreads_);
-
-        return do_run(std::move(action), concurrency, true);
+        do_run(std::move(action), concurrency, true);
     }
 };
 

--- a/include/sysmakeshift/thread_squad.hpp
+++ b/include/sysmakeshift/thread_squad.hpp
@@ -65,14 +65,13 @@ public:
         //
     class task_context
     {
-        friend detail::thread_squad_thread;
         friend detail::thread_squad_impl;
 
     private:
         detail::thread_squad_impl_base& impl_;
         int threadIdx_;
 
-        explicit task_context(detail::thread_squad_impl_base& _impl, int _threadIdx) noexcept
+        task_context(detail::thread_squad_impl_base& _impl, int _threadIdx) noexcept
             : impl_(_impl), threadIdx_(_threadIdx)
         {
         }
@@ -93,7 +92,7 @@ public:
         gsl_NODISCARD int
         num_threads(void) const noexcept
         {
-            return impl_.numThreads_;
+            return impl_.numThreads;
         }
     };
 
@@ -136,7 +135,7 @@ public:
     gsl_NODISCARD int
     num_threads(void) const
     {
-        return handle_->numThreads_;
+        return handle_->numThreads;
     }
 
         //
@@ -151,7 +150,7 @@ public:
     run(std::function<void(task_context)> action, int concurrency = 0) &
     {
         gsl_Expects(action);
-        gsl_Expects(concurrency >= 0 && concurrency <= handle_->numThreads_);
+        gsl_Expects(concurrency >= 0 && concurrency <= handle_->numThreads);
 
         do_run(std::move(action), concurrency, false);
     }
@@ -168,7 +167,7 @@ public:
     run(std::function<void(task_context)> action, int concurrency = 0) &&
     {
         gsl_Expects(action);
-        gsl_Expects(concurrency >= 0 && concurrency <= handle_->numThreads_);
+        gsl_Expects(concurrency >= 0 && concurrency <= handle_->numThreads);
 
         do_run(std::move(action), concurrency, true);
     }

--- a/src/sysmakeshift.natvis
+++ b/src/sysmakeshift.natvis
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
+
+    <Type Name="sysmakeshift::aligned_buffer&lt;*,*,*&gt;">
+        <DisplayString Condition="size_ == 0">{{ size={ size_ } data={{}} }}</DisplayString>
+        <DisplayString Condition="size_ == 1">{{ size={ size_ } data={{{ *($T1*)data_ }}} }}</DisplayString>
+        <DisplayString Condition="size_ == 2">{{ size={ size_ } data={{{ *($T1*)data_ }, { *($T1*)(data_ + bytesPerElement_*1) }}} }}</DisplayString>
+        <DisplayString Condition="size_ == 3">{{ size={ size_ } data={{{ *($T1*)data_ }, { *($T1*)(data_ + bytesPerElement_*1) }, { *($T1*)(data_ + bytesPerElement_*2) }}} }}</DisplayString>
+        <DisplayString Condition="size_ == 4">{{ size={ size_ } data={{{ *($T1*)data_ }, { *($T1*)(data_ + bytesPerElement_*1) }, { *($T1*)(data_ + bytesPerElement_*2) }, { *($T1*)(data_ + bytesPerElement_*3) }}} }}</DisplayString>
+        <DisplayString Condition="size_ == 5">{{ size={ size_ } data={{{ *($T1*)data_ }, { *($T1*)(data_ + bytesPerElement_*1) }, { *($T1*)(data_ + bytesPerElement_*2) }, { *($T1*)(data_ + bytesPerElement_*3) }, { *($T1*)(data_ + bytesPerElement_*4) }}} }}</DisplayString>
+        <DisplayString Condition="size_ == 6">{{ size={ size_ } data={{{ *($T1*)data_ }, { *($T1*)(data_ + bytesPerElement_*1) }, { *($T1*)(data_ + bytesPerElement_*2) }, { *($T1*)(data_ + bytesPerElement_*3) }, { *($T1*)(data_ + bytesPerElement_*4) }, { *($T1*)(data_ + bytesPerElement_*5) }}}</DisplayString>
+        <Expand>
+            <Item Name="[size]">size_</Item>
+            <IndexListItems>
+                <Size>size_</Size>
+                <ValueNode>*($T1*)(data_ + bytesPerElement_*$i)</ValueNode>
+            </IndexListItems>
+        </Expand>
+    </Type>
+    <!--Type Name="sysmakeshift::aligned_row_buffer&lt;*,*,*&gt;">
+        <DisplayString Condition="size_ == 0">{{ }}</DisplayString>
+        <DisplayString Condition="size_ == 1">{{ {(*this)[0]} }}</DisplayString>
+        <DisplayString Condition="size_ == 2">{{ {(*this)[0]}, {(*this)[1]} }}</DisplayString>
+        <DisplayString Condition="size_ == 3">{{ {(*this)[0]}, {(*this)[1]}, {(*this)[2]} }}</DisplayString>
+        <DisplayString Condition="size_ == 4">{{ {(*this)[0]}, {(*this)[1]}, {(*this)[2]}, {(*this)[3]} }}</DisplayString>
+        <DisplayString Condition="size_ == 5">{{ {(*this)[0]}, {(*this)[1]}, {(*this)[2]}, {(*this)[3]}, {(*this)[4]} }}</DisplayString>
+        <DisplayString Condition="size_ == 6">{{ {(*this)[0]}, {(*this)[1]}, {(*this)[2]}, {(*this)[3]}, {(*this)[4]}, {(*this)[5]} }}</DisplayString>
+        <Expand>
+            <Item Name="[rows]">rows_</Item>
+            <Item Name="[cols]">cols_</Item>
+            <IndexListItems>
+                <Size>rows_*cols_</Size>
+                <ValueNode>*($T1*)((*this) + bytesPerRow_*($i))</ValueNode>
+            </IndexListItems>
+        </Expand>
+    </Type-->
+
+</AutoVisualizer>

--- a/src/thread_squad.cpp
+++ b/src/thread_squad.cpp
@@ -325,7 +325,7 @@ bool wait_equal_exponential_backoff(std::atomic<T>& a, T expected)
             }
             n *= 2;
         }
-        _mm_pause();
+        detail::pause();
     }
     for (int i = 0; i < (1 << yieldCount); ++i)
     {

--- a/src/thread_squad.cpp
+++ b/src/thread_squad.cpp
@@ -319,7 +319,7 @@ bool wait_equal_exponential_backoff(std::atomic<T>& a, T expected)
             {
                 for (int k = 0; k < n; ++k)
                 {
-                    [[maybe_unused]] volatile int v = k;
+                    [[maybe_unused]] volatile int v = j + k;
                 }
                 if (a.load(std::memory_order_relaxed) == expected) return true;
             }
@@ -402,18 +402,16 @@ struct thread_sync_data
 static int
 next_substride(int stride)
 {
+    return (stride + 7) / 8;
+    /*if (stride % 3 == 0)
+    {
+        return stride /= 3;
+    }
     if (stride % 2 == 0)
     {
         return stride /= 2;
     }
-    else if (stride % 3 == 0)
-    {
-        return stride /= 3;
-    }
-    else
-    {
-        return (stride + 1) / 2;
-    }
+    return (stride + 1) / 2;*/
 }
 
 

--- a/test/test-thread_squad.cpp
+++ b/test/test-thread_squad.cpp
@@ -20,6 +20,7 @@ TEST_CASE("thread_squad can schedule single task")
     GENERATE(range(0, 20)); // repetitions
 
     int numThreads = GENERATE(0, 1, 3, 10, 50);
+
     unsigned numActualThreads = static_cast<unsigned>(numThreads);
     if (numActualThreads == 0)
     {
@@ -59,7 +60,7 @@ TEST_CASE("thread_squad can schedule multiple tasks")
 {
     GENERATE(range(0, 10)); // repetitions
 
-    int numThreads = GENERATE(0, 1, 3, 10, 50);
+    int numThreads = GENERATE(range(0, 10), 10, 48, 50);
     unsigned numActualThreads = static_cast<unsigned>(numThreads);
     if (numActualThreads == 0)
     {

--- a/test/test-thread_squad.cpp
+++ b/test/test-thread_squad.cpp
@@ -45,15 +45,7 @@ TEST_CASE("thread_squad can schedule single task")
         threadIndices.insert(ctx.thread_index());
     };
 
-    SECTION("with synchronous completion")
-    {
-        sysmakeshift::thread_squad(params).run(action);
-    }
-    SECTION("with asynchronous completion")
-    {
-        auto completion = sysmakeshift::thread_squad(params).run_async(action);
-        completion.wait();
-    }
+    sysmakeshift::thread_squad(params).run(action);
 
     CAPTURE(numThreads);
 
@@ -95,26 +87,10 @@ TEST_CASE("thread_squad can schedule multiple tasks")
         ++threadIndex_Count[ctx.thread_index()];
     };
 
-    SECTION("with synchronous completion")
+    auto threadSquad = sysmakeshift::thread_squad(params);
+    for (int i = 0; i < numTasks; ++i)
     {
-        auto threadSquad = sysmakeshift::thread_squad(params);
-        for (int i = 0; i < numTasks; ++i)
-        {
-            threadSquad.run(action);
-        }
-    }
-    SECTION("with asynchronous completion")
-    {
-        std::vector<std::future<void>> completions;
-        auto threadSquad = sysmakeshift::thread_squad(params);
-        for (int i = 0; i < numTasks; ++i)
-        {
-            completions.push_back(threadSquad.run_async(action));
-        }
-        for (auto& completion : completions)
-        {
-            completion.wait();
-        }
+        threadSquad.run(action);
     }
 
     CAPTURE(numThreads);


### PR DESCRIPTION
* Improve scalability of `thread_squad` with tree barrier

  Using a tree-like wait chain significantly reduces contention on large multiprocessor machines.

* Use atomic waits with exponential backoff

* Remove `thread_squad::run_async()`

  This lets us focus on the synchronous use case. It also gets rid of the \<future\> header dependency in \<sysmakeshift/thread_squad.hpp\>.

* Add debugger visualizer for `aligned_buffer<>`