### PR TITLE
Fix `thread_squad` undersubscription and avoid redundant wakeups

### DIFF
--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -33,6 +33,12 @@ jobs:
       platforms: [x86, x64]
 
     - os: Windows
+      cxxCompiler: MSVC
+      cxxCompilerVersions: [19_2]
+      platforms: [x86, x64]
+      cmakeBuildConfigurations: [Release]
+
+    - os: Windows
       cxxCompiler: Clang
       cxxCompilerVersions: [9]
       platforms: [x86, x64]
@@ -46,9 +52,15 @@ jobs:
       cxxCompiler: GCC
       cxxCompilerVersions: [9]
       platforms: [x64]
-      tag: 'sanitize'
+      cmakeBuildConfigurations: [Release]
+
+    - os: Linux
+      cxxCompiler: GCC
+      cxxCompilerVersions: [9]
+      platforms: [x64]
       vcpkgTriplet: <platform>-<os>-sanitize
       cmakeConfigArgs: '<cmakeConfigArgs> -DCMAKESHIFT_PRIVATE_COMPILE_SETTINGS=runtime-checks;debug-stdlib'
+      tag: 'sanitize'
 
     - os: Linux
       cxxCompiler: Clang
@@ -59,9 +71,15 @@ jobs:
       cxxCompiler: Clang
       cxxCompilerVersions: [9]
       platforms: [x64]
-      tag: 'sanitize'
+      cmakeBuildConfigurations: [Release]
+
+    - os: Linux
+      cxxCompiler: Clang
+      cxxCompilerVersions: [9]
+      platforms: [x64]
       vcpkgTriplet: <platform>-<os>-sanitize
       cmakeConfigArgs: '<cmakeConfigArgs> -DCMAKESHIFT_PRIVATE_COMPILE_SETTINGS=runtime-checks;debug-stdlib'
+      tag: 'sanitize'
 
     - os: MacOS
       cxxCompiler: GCC
@@ -69,6 +87,18 @@ jobs:
       platforms: [x64]
 
     - os: MacOS
+      cxxCompiler: GCC
+      cxxCompilerVersions: [9]
+      platforms: [x64]
+      cmakeBuildConfigurations: [Release]
+
+    - os: MacOS
       cxxCompiler: AppleClang
       cxxCompilerVersions: [10, 10_0_1, 11]
       platforms: [x64]
+
+    - os: MacOS
+      cxxCompiler: AppleClang
+      cxxCompilerVersions: [11]
+      platforms: [x64]
+      cmakeBuildConfigurations: [Release]

--- a/include/sysmakeshift/detail/thread_squad.hpp
+++ b/include/sysmakeshift/detail/thread_squad.hpp
@@ -17,6 +17,8 @@ struct thread_squad_impl_base
 };
 struct thread_squad_impl;
 
+class thread_squad_data;
+
 struct thread_squad_impl_deleter
 {
     void

--- a/include/sysmakeshift/detail/thread_squad.hpp
+++ b/include/sysmakeshift/detail/thread_squad.hpp
@@ -15,9 +15,7 @@ struct thread_squad_impl_base
 {
     int numThreads;
 };
-struct thread_squad_impl;
-
-class thread_squad_data;
+class thread_squad_impl;
 
 struct thread_squad_impl_deleter
 {

--- a/include/sysmakeshift/thread_squad.hpp
+++ b/include/sysmakeshift/thread_squad.hpp
@@ -65,7 +65,7 @@ public:
         //
     class task_context
     {
-        friend detail::thread_squad_impl;
+        friend detail::thread_squad_data;
 
     private:
         detail::thread_squad_impl_base& impl_;

--- a/include/sysmakeshift/thread_squad.hpp
+++ b/include/sysmakeshift/thread_squad.hpp
@@ -65,7 +65,7 @@ public:
         //
     class task_context
     {
-        friend detail::thread_squad_data;
+        friend detail::thread_squad_impl;
 
     private:
         detail::thread_squad_impl_base& impl_;

--- a/include/sysmakeshift/thread_squad.hpp
+++ b/include/sysmakeshift/thread_squad.hpp
@@ -139,15 +139,28 @@ public:
     }
 
         //
-        // Runs the given action on `concurrency` threads and waits until all tasks have run to completion.
+        // Runs the given action on all threads and waits until all tasks have run to completion.
         //ᅟ
-        // `concurrency == 0` indicates that the maximum concurrency level should be used, i.e. the task is run on all threads in
-        // the thread squad. `concurrency` must not exceed the number of threads in the thread squad.
         // The thread squad makes a dedicated copy of `action` for every participating thread and invokes it with an appropriate
         // task context. If `action()` throws an exception, `std::terminate()` is called.
         //
     void
-    run(std::function<void(task_context)> action, int concurrency = 0) &
+    run(std::function<void(task_context)> action) &
+    {
+        gsl_Expects(action);
+
+        do_run(std::move(action), handle_->numThreads, false);
+    }
+
+        //
+        // Runs the given action on `concurrency` threads and waits until all tasks have run to completion.
+        //ᅟ
+        // `concurrency` must not exceed the number of threads in the thread squad.
+        // The thread squad makes a dedicated copy of `action` for every participating thread and invokes it with an appropriate
+        // task context. If `action()` throws an exception, `std::terminate()` is called.
+        //
+    void
+    run(std::function<void(task_context)> action, int concurrency) &
     {
         gsl_Expects(action);
         gsl_Expects(concurrency >= 0 && concurrency <= handle_->numThreads);
@@ -156,15 +169,28 @@ public:
     }
 
         //
-        // Runs the given action on `concurrency` threads and waits until all tasks have run to completion.
+        // Runs the given action on all threads and waits until all tasks have run to completion.
         //ᅟ
-        // `concurrency == 0` indicates that the maximum concurrency level should be used, i.e. the task is run on all threads in
-        // the thread squad. `concurrency` must not exceed the number of threads in the thread squad.
         // The thread squad makes a dedicated copy of `action` for every participating thread and invokes it with an appropriate
         // task context. If `action()` throws an exception, `std::terminate()` is called.
         //
     void
-    run(std::function<void(task_context)> action, int concurrency = 0) &&
+    run(std::function<void(task_context)> action) &&
+    {
+        gsl_Expects(action);
+
+        do_run(std::move(action), handle_->numThreads, true);
+    }
+
+        //
+        // Runs the given action on `concurrency` threads and waits until all tasks have run to completion.
+        //ᅟ
+        // `concurrency` must not exceed the number of threads in the thread squad.
+        // The thread squad makes a dedicated copy of `action` for every participating thread and invokes it with an appropriate
+        // task context. If `action()` throws an exception, `std::terminate()` is called.
+        //
+    void
+    run(std::function<void(task_context)> action, int concurrency) &&
     {
         gsl_Expects(action);
         gsl_Expects(concurrency >= 0 && concurrency <= handle_->numThreads);

--- a/src/thread_squad.cpp
+++ b/src/thread_squad.cpp
@@ -410,7 +410,7 @@ private:
     std::size_t coreAffinity_;
 
 public:
-    constexpr os_thread(void)
+    os_thread(void)
         : coreAffinity_(std::size_t(-1))
     {
     }
@@ -460,7 +460,7 @@ public:
 # endif // USE_PTHREAD_SETAFFINITY
         auto lhandle = pthread_t{ };
         detail::posix_check(::pthread_create(&lhandle, &attr.attr, proc, ctx));
-        handle_ = pthread_handle(handle);
+        handle_ = pthread_handle(lhandle);
 #else
 # error Unsupported operating system
 #endif
@@ -745,6 +745,11 @@ public:
         {
             for (int i = 0; i < numThreads; ++i)
             {
+    #ifdef DEBUG_WAIT_CHAIN
+                std::printf("thread squad #%u, thread -1: pin %d to CPU %d\n", threadSquadId_, i,
+                    int(detail::get_hardware_thread_id(i, params.max_num_hardware_threads, params.hardware_thread_mappings)));
+                std::fflush(stdout);
+    #endif // DEBUG_WAIT_CHAIN
                 threadData_[i].osThread_.set_core_affinity(
                     detail::get_hardware_thread_id(i, params.max_num_hardware_threads, params.hardware_thread_mappings));
             }

--- a/src/thread_squad.cpp
+++ b/src/thread_squad.cpp
@@ -824,7 +824,6 @@ public:
 static void
 run_thread(thread_squad_impl::thread_data& threadData)
 {
-    bool justWoken = true;
     int pass = 0;
     for (;;)
     {
@@ -833,7 +832,6 @@ run_thread(thread_squad_impl::thread_data& threadData)
         threadData.task_run(task);
         threadData.wait_for_subthreads();
         threadData.task_signal_completion();
-        justWoken = false;
         ++pass;
         if (task.terminationRequested) break;
     }
@@ -909,7 +907,7 @@ thread_squad_thread_func(void* ctx)
         detail::posix_check(::pthread_setname_np(::pthread_self(), buf));
 #elif defined(__APPLE__)
         char buf[64];
-        std::sprintf(buf, L"sysmakeshift thread squad #%u, thread %d",
+        std::sprintf(buf, "sysmakeshift thread squad #%u, thread %d",
             threadData.thread_squad_id(), threadData.thread_idx());
         detail::posix_check(::pthread_setname_np(buf));
 #endif

--- a/src/thread_squad.cpp
+++ b/src/thread_squad.cpp
@@ -371,7 +371,8 @@ void store_and_notify(
 {
     {
         auto lock = std::lock_guard(mutex);
-        a.store(newValue, std::memory_order_relaxed);
+        //a.store(newValue, std::memory_order_relaxed);
+        a.fetch_xor(1, std::memory_order_relaxed);
     }
     cv.notify_one();
 }
@@ -758,7 +759,8 @@ noexcept // We cannot really handle exceptions here.
         {
             for (int i = 0; i < self.numThreads; ++i)
             {
-                self.threadSyncData[i].newSense.store(1 ^ self.threadSyncData[i].sense.load(std::memory_order_relaxed), std::memory_order_relaxed);
+                //self.threadSyncData[i].newSense.store(1 ^ self.threadSyncData[i].sense.load(std::memory_order_relaxed), std::memory_order_relaxed);
+                self.threadSyncData[i].newSense.fetch_xor(1, std::memory_order_relaxed);
             }
             detail::launch_threads(self);
         }

--- a/src/thread_squad.cpp
+++ b/src/thread_squad.cpp
@@ -754,7 +754,7 @@ noexcept // We cannot really handle exceptions here.
             int numThreadsToWake = join ? self.numThreads : concurrency;
             for (int i = 0; i < numThreadsToWake; ++i)
             {
-                self.threadSyncData[i].newSense.fetch_xor(1, std::memory_order_relaxed);
+                self.threadSyncData[i].newSense.store(1, std::memory_order_relaxed);
             }
             detail::launch_threads(self);
         }

--- a/src/thread_squad.cpp
+++ b/src/thread_squad.cpp
@@ -171,7 +171,8 @@ public:
 
 #endif // _WIN32
 
-static void
+#ifdef THREAD_PINNING_SUPPORTED
+[[maybe_unused]] static void
 setThreadAffinity(std::thread::native_handle_type handle, std::size_t coreIdx)
 {
 # if defined(_WIN32)
@@ -189,7 +190,7 @@ setThreadAffinity(std::thread::native_handle_type handle, std::size_t coreIdx)
 # endif
 }
 
-#ifdef USE_PTHREAD_SETAFFINITY
+# ifdef USE_PTHREAD_SETAFFINITY
 static void
 setThreadAttrAffinity(pthread_attr_t& attr, std::size_t coreIdx)
 {
@@ -197,8 +198,8 @@ setThreadAttrAffinity(pthread_attr_t& attr, std::size_t coreIdx)
     cpuSet.set_cpu_flag(coreIdx);
     detail::posix_check(::pthread_attr_setaffinity_np(&attr, cpuSet.size(), cpuSet.data()));
 }
-#endif // USE_PTHREAD_SETAFFINITY
-
+# endif // USE_PTHREAD_SETAFFINITY
+#endif // THREAD_PINNING_SUPPORTED
 
 #if defined(_WIN32)
 struct win32_handle_deleter
@@ -569,29 +570,28 @@ public:
         }
 
         void
-        notify_subthreads(int mySense) noexcept
+        notify_subthreads(void) noexcept
         {
             int numThreadsToWake = threadSquad_.task_.terminationRequested
                 ? threadSquad_.numThreads
                 : threadSquad_.task_.concurrency;
-            threadSquad_.notify_subthreads(mySense, threadIdx_, numThreadsToWake);
+            threadSquad_.notify_subthreads(threadIdx_, numThreadsToWake);
         }
 
         void
-        wait_for_subthreads(int mySense) noexcept
+        wait_for_subthreads(void) noexcept
         {
             int numThreadsToWaitFor = threadSquad_.task_.terminationRequested
                 ? threadSquad_.numThreads
                 : threadSquad_.task_.concurrency;
-            threadSquad_.wait_for_subthreads(mySense, threadIdx_, numThreadsToWaitFor);
+            threadSquad_.wait_for_subthreads(threadIdx_, numThreadsToWaitFor);
         }
 
         task
-        task_wait(int mySense) noexcept
+        task_wait(void) noexcept
         {
             auto& notifyData = threadSquad_.threadNotifyData_[threadIdx_];
             auto oldSense = sense_.load(std::memory_order_relaxed);
-            //gsl_Expects(oldSense == mySense);
             detail::wait_and_load(notifyData.mutex, notifyData.cv, newSense_, oldSense);
             THREAD_SQUAD_DBG("thread squad #%u, thread %d: started\n", threadSquad_.threadSquadId_, threadIdx_);
             return threadSquad_.task_;
@@ -609,11 +609,10 @@ public:
         }
 
         void
-        task_signal_completion(int mySense) noexcept
+        task_signal_completion(void) noexcept
         {
             THREAD_SQUAD_DBG("thread squad #%u, thread %d: signaling\n", threadSquad_.threadSquadId_, threadIdx_);
             auto& notifyData = threadSquad_.threadNotifyData_[threadIdx_];
-            //gsl_Expects(sense_.load(std::memory_order_relaxed) == mySense);
             detail::toggle_and_notify(notifyData.mutex, notifyData.cv, sense_);
             //sense_.store(newSense_.load(std::memory_order_relaxed), std::memory_order_release);
         }
@@ -658,10 +657,6 @@ private:
         // debugging data
     unsigned threadSquadId_; // for runtime thread identification during debugging
 
-public:
-    int mySense_;
-private:
-
 
     thread_squad::task_context
     make_context_for(int threadIdx) noexcept
@@ -690,14 +685,14 @@ private:
     }
 
     void
-    notify_subthreads_impl(int mySense, int first, int last, int stride)
+    notify_subthreads_impl(int first, int last, int stride)
     {
         while (stride != 1)
         {
             int substride = next_substride(stride);
             for (int i = first + substride; i < last; i += substride)
             {
-                notify_thread(mySense, first, i);
+                notify_thread(first, i);
             }
             last = std::min(first + substride, last);
             stride = substride;
@@ -705,12 +700,12 @@ private:
     }
 
     void
-    wait_for_subthreads_impl(int mySense, int first, int last, int stride)
+    wait_for_subthreads_impl(int first, int last, int stride)
     {
         int substride = next_substride(stride);
         if (stride != 1)
         {
-            wait_for_subthreads_impl(mySense, first, std::min(first + substride, last), substride);
+            wait_for_subthreads_impl(first, std::min(first + substride, last), substride);
         }
         if (task_.terminationRequested)
         {
@@ -733,7 +728,7 @@ private:
         }
         for (int i = first + substride; i < last; i += substride)
         {
-            wait_for_thread(mySense, first, i);
+            wait_for_thread(first, i);
         }
     }
 
@@ -743,8 +738,7 @@ public:
         : thread_squad_impl_base{ params.num_threads },
           threadNotifyData_(gsl::narrow<std::size_t>(params.num_threads)),
           threadData_(gsl::narrow<std::size_t>(params.num_threads), std::in_place, *this),
-          threadSquadId_(threadSquadCounter.fetch_add(1, std::memory_order_acq_rel)),
-          mySense_(0)
+          threadSquadId_(threadSquadCounter.fetch_add(1, std::memory_order_acq_rel))
     {
         for (int i = 0; i < numThreads; ++i)
         {
@@ -773,10 +767,9 @@ public:
     }
 
     void
-    notify_thread(int mySense, [[maybe_unused]] int callingThreadIdx, int targetThreadIdx)
+    notify_thread([[maybe_unused]] int callingThreadIdx, int targetThreadIdx)
     {
         THREAD_SQUAD_DBG("thread squad #%u, thread %d: notifying %d\n", threadSquadId_, callingThreadIdx, targetThreadIdx);
-        //gsl_Expects(threadData_[targetThreadIdx].newSense_.load(std::memory_order_relaxed) == mySense);
         detail::toggle_and_notify(threadNotifyData_[targetThreadIdx].mutex, threadNotifyData_[targetThreadIdx].cv, threadData_[targetThreadIdx].newSense_);
 
         if (!threadData_[targetThreadIdx].osThread_.is_running())
@@ -787,7 +780,7 @@ public:
     }
 
     void
-    wait_for_thread(int mySense, [[maybe_unused]] int callingThreadIdx, int targetThreadIdx, bool spinWait = true)
+    wait_for_thread([[maybe_unused]] int callingThreadIdx, int targetThreadIdx, bool spinWait = true)
     {
         if (task_.terminationRequested && threadData_[targetThreadIdx].osThread_.is_running())
         {
@@ -798,24 +791,23 @@ public:
 
         int newSense_ = threadData_[targetThreadIdx].newSense_.load(std::memory_order_relaxed);
         int oldSense = 1 ^ newSense_;
-        //gsl_Expects(oldSense == mySense);
         //detail::atomic_wait_while_equal(threadData_[targetThreadIdx].sense_, oldSense, spinWait);
         detail::wait_and_load(threadNotifyData_[targetThreadIdx].mutex, threadNotifyData_[targetThreadIdx].cv, threadData_[targetThreadIdx].sense_, oldSense, spinWait);
         THREAD_SQUAD_DBG("thread squad #%u, thread %d: awaited %d\n", threadSquadId_, callingThreadIdx, targetThreadIdx);
     }
 
     void
-    notify_subthreads(int mySense, int callingThreadIdx, int _concurrency)
+    notify_subthreads(int callingThreadIdx, int _concurrency)
     {
         int stride = threadData_[callingThreadIdx].numSubthreads_;
-        notify_subthreads_impl(mySense, callingThreadIdx, std::min(callingThreadIdx + stride, _concurrency), stride);
+        notify_subthreads_impl(callingThreadIdx, std::min(callingThreadIdx + stride, _concurrency), stride);
     }
 
     void
-    wait_for_subthreads(int mySense, int callingThreadIdx, int _concurrency)
+    wait_for_subthreads(int callingThreadIdx, int _concurrency)
     {
         int stride = threadData_[callingThreadIdx].numSubthreads_;
-        wait_for_subthreads_impl(mySense, callingThreadIdx, std::min(callingThreadIdx + stride, _concurrency), stride);
+        wait_for_subthreads_impl(callingThreadIdx, std::min(callingThreadIdx + stride, _concurrency), stride);
     }
 
     void
@@ -849,17 +841,15 @@ static void
 run_thread(thread_squad_impl::thread_data& threadData)
 {
     bool justWoken = true;
-    int mySense = 0;
     int pass = 0;
     for (;;)
     {
-        auto task = threadData.task_wait(mySense);
-        threadData.notify_subthreads(mySense);
+        auto task = threadData.task_wait();
+        threadData.notify_subthreads();
         threadData.task_run(task);
-        threadData.wait_for_subthreads(mySense);
-        threadData.task_signal_completion(mySense);
+        threadData.wait_for_subthreads();
+        threadData.task_signal_completion();
         justWoken = false;
-        mySense = 1 ^ mySense;
         ++pass;
         if (task.terminationRequested) break;
     }
@@ -894,10 +884,9 @@ noexcept // We cannot really handle exceptions here.
     if (haveWork)
     {
         self.store_task({ std::move(action), concurrency, join });
-        self.notify_thread(self.mySense_, -1, 0);
-        self.wait_for_thread(self.mySense_, -1, 0, false); // no spin wait in main thread
+        self.notify_thread(-1, 0);
+        self.wait_for_thread(-1, 0, false); // no spin wait in main thread
         self.release_task();
-        self.mySense_ = 1 ^ self.mySense_;
     }
 }
 

--- a/src/thread_squad.cpp
+++ b/src/thread_squad.cpp
@@ -439,7 +439,7 @@ public:
 # ifdef USE_PTHREAD_SETAFFINITY
         if (coreAffinity_ != std::size_t(-1))
         {
-            detail::setThreadAffinity(handle_.get(), codeAffinity_);
+            detail::setThreadAffinity(::pthread_self(), coreAffinity_);
         }
 # endif // USE_PTHREAD_SETAFFINITY
     }
@@ -932,6 +932,12 @@ static void*
 thread_squad_thread_func(void* ctx)
 {
     auto& threadData = thread_squad_impl::thread_data::from_thread_context(ctx);
+    {
+        char buf[64];
+        std::sprintf(buf, "sysmakeshift thread squad #%u, thread %d",
+            threadData.thread_squad_id(), threadData.thread_idx());
+        ::pthread_setname_np(::pthread_self(), buf);
+    }
 
     detail::run_thread(threadData);
 

--- a/src/thread_squad.cpp
+++ b/src/thread_squad.cpp
@@ -554,6 +554,7 @@ wait_for_thread(
 }
 
 
+#ifdef THREAD_PINNING_SUPPORTED
 static std::size_t
 get_hardware_thread_id(int threadIdx, int maxNumHardwareThreads, gsl::span<int const> hardwareThreadMappings)
 {
@@ -562,6 +563,7 @@ get_hardware_thread_id(int threadIdx, int maxNumHardwareThreads, gsl::span<int c
         !hardwareThreadMappings.empty() ? hardwareThreadMappings[subidx]
         : subidx);
 }
+#endif // THREAD_PINNING_SUPPORTED
 
 
 #if defined(_WIN32)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,7 +10,7 @@ cmake_minimum_required(VERSION 3.14)
 find_package(CMakeshift 3.8 REQUIRED)
 find_package(Threads REQUIRED)
 find_package(gsl-lite 0.36 REQUIRED)
-find_package(Catch2 2.9 REQUIRED)
+find_package(Catch2 2.11 REQUIRED)
 
 include(CMakeshift/TargetCompileSettings)
 

--- a/test/test-thread_squad.cpp
+++ b/test/test-thread_squad.cpp
@@ -28,7 +28,6 @@ TEST_CASE("thread_squad")
     {
         numActualThreads = std::thread::hardware_concurrency();
     }
-    unsigned numHardwareThreadsUsed = std::min(numActualThreads, std::thread::hardware_concurrency());
 
     std::mutex mutex;
     auto threadId_Count = std::unordered_map<std::thread::id, int>{ };
@@ -54,10 +53,6 @@ TEST_CASE("thread_squad")
     SECTION("single task")
     {
         sysmakeshift::thread_squad(params).run(action);
-        if (params.pin_to_hardware_threads)
-        {
-            CHECK(threadId_Count.size() == static_cast<std::size_t>(numHardwareThreadsUsed));
-        }
         CHECK(threadIndex_Count.size() == static_cast<std::size_t>(numActualThreads));
     }
 
@@ -76,7 +71,7 @@ TEST_CASE("thread_squad")
         {
             if (params.pin_to_hardware_threads)
             {
-                CHECK(threadId_Count.size() == static_cast<std::size_t>(numHardwareThreadsUsed));
+                CHECK(threadId_Count.size() == static_cast<std::size_t>(numActualThreads));
             }
             CHECK(threadIndex_Count.size() == static_cast<std::size_t>(numActualThreads));
         }

--- a/test/test-thread_squad.cpp
+++ b/test/test-thread_squad.cpp
@@ -94,6 +94,8 @@ TEST_CASE("thread_squad")
 
     SECTION("no deadlocks")
     {
+        GENERATE(range(0, 10)); // more repetitions
+
         int numTasks = GENERATE(0, 1, 2, 5, 10, 20);
         CAPTURE(numTasks);
 

--- a/test/test-thread_squad.cpp
+++ b/test/test-thread_squad.cpp
@@ -94,7 +94,7 @@ TEST_CASE("thread_squad")
 
     SECTION("no deadlocks")
     {
-        GENERATE(range(0, 10)); // more repetitions
+        GENERATE(range(0, 3)); // more repetitions
 
         int numTasks = GENERATE(0, 1, 2, 5, 10, 20);
         CAPTURE(numTasks);
@@ -102,6 +102,7 @@ TEST_CASE("thread_squad")
         auto threadSquad = sysmakeshift::thread_squad(params);
         for (int i = 0; i < numTasks; ++i)
         {
+            CAPTURE(i);
             threadSquad.run([](auto const&){ });
         }
     }

--- a/test/test-thread_squad.cpp
+++ b/test/test-thread_squad.cpp
@@ -31,7 +31,7 @@ TEST_CASE("thread_squad")
     std::mutex mutex;
     auto threadId_Count = std::unordered_map<std::thread::id, int>{ };
     auto threadIndex_Count = std::unordered_map<int, int>{ };
-	int count = 0;
+    int count = 0;
 
     auto params = sysmakeshift::thread_squad::params{
         /*.num_threads = */ numThreads
@@ -46,16 +46,16 @@ TEST_CASE("thread_squad")
         auto lock = std::unique_lock<std::mutex>(mutex);
         ++threadId_Count[std::this_thread::get_id()];
         ++threadIndex_Count[ctx.thread_index()];
-		++count;
+        ++count;
     };
 
     SECTION("single task")
     {
         sysmakeshift::thread_squad(params).run(action);
 #ifdef THREAD_PINNING_SUPPORTED
-	    CHECK(threadId_Count.size() == static_cast<std::size_t>(numActualThreads));
+        CHECK(threadId_Count.size() == static_cast<std::size_t>(numActualThreads));
 #endif // THREAD_PINNING_SUPPORTED
-    	CHECK(threadIndex_Count.size() == static_cast<std::size_t>(numActualThreads));
+        CHECK(threadIndex_Count.size() == static_cast<std::size_t>(numActualThreads));
     }
 
     SECTION("fixed number of tasks")
@@ -63,42 +63,41 @@ TEST_CASE("thread_squad")
         int numTasks = GENERATE(0, 1, 2, 5, 10, 20);
         CAPTURE(numTasks);
 
-	    auto threadSquad = sysmakeshift::thread_squad(params);
-    	for (int i = 0; i < numTasks; ++i)
-	    {
-    	    threadSquad.run(action);
-	    }
+        auto threadSquad = sysmakeshift::thread_squad(params);
+        for (int i = 0; i < numTasks; ++i)
+        {
+            threadSquad.run(action);
+        }
 
-	    if (numTasks != 0)
-    	{
+        if (numTasks != 0)
+        {
 #ifdef THREAD_PINNING_SUPPORTED
-	        CHECK(threadId_Count.size() == static_cast<std::size_t>(numActualThreads));
+            CHECK(threadId_Count.size() == static_cast<std::size_t>(numActualThreads));
 #endif // THREAD_PINNING_SUPPORTED
-    	    CHECK(threadIndex_Count.size() == static_cast<std::size_t>(numActualThreads));
-	    }
+            CHECK(threadIndex_Count.size() == static_cast<std::size_t>(numActualThreads));
+        }
 
 #ifdef THREAD_PINNING_SUPPORTED
-	    for (auto const& id_count : threadId_Count)
-    	{
-        	CHECK(id_count.second == numTasks);
-	    }
+        for (auto const& id_count : threadId_Count)
+        {
+            CHECK(id_count.second == numTasks);
+        }
 #endif // THREAD_PINNING_SUPPORTED
-    	for (auto const& index_count : threadIndex_Count)
-	    {
-    	    CHECK(index_count.second == numTasks);
-	    }
-	}
+        for (auto const& index_count : threadIndex_Count)
+        {
+            CHECK(index_count.second == numTasks);
+        }
+    }
 
     SECTION("fixed number of tasks")
     {
-	    auto threadSquad = sysmakeshift::thread_squad(params);
-		for (int i = 1; i <= int(numActualThreads); ++i)
-		{
-			CAPTURE(i);
-			threadSquad.run(action, i);
-		}
+        auto threadSquad = sysmakeshift::thread_squad(params);
+        for (int i = 1; i <= int(numActualThreads); ++i)
+        {
+            CAPTURE(i);
+            threadSquad.run(action, i);
+        }
 
-		CHECK(count == numActualThreads * (numActualThreads + 1) / 2);
-	}
+        CHECK(count == int(numActualThreads * (numActualThreads + 1) / 2));
+    }
 }
-

--- a/test/test-thread_squad.cpp
+++ b/test/test-thread_squad.cpp
@@ -104,7 +104,7 @@ TEST_CASE("thread_squad")
         }
     }
 
-    SECTION("fixed number of tasks")
+    SECTION("varying concurrency")
     {
         auto threadSquad = sysmakeshift::thread_squad(params);
         for (int i = 1; i <= int(numActualThreads); ++i)

--- a/test/test-thread_squad.cpp
+++ b/test/test-thread_squad.cpp
@@ -15,63 +15,23 @@
 
 
 
-TEST_CASE("thread_squad can schedule single task")
-{
-    GENERATE(range(0, 20)); // repetitions
-
-    int numThreads = GENERATE(0, 1, 3, 10, 50);
-
-    unsigned numActualThreads = static_cast<unsigned>(numThreads);
-    if (numActualThreads == 0)
-    {
-        numActualThreads = std::thread::hardware_concurrency();
-    }
-
-    std::mutex mutex;
-    std::unordered_set<std::thread::id> threadIds;
-    std::unordered_set<int> threadIndices;
-
-    auto params = sysmakeshift::thread_squad::params{
-        /*.num_threads = */ numThreads
-    };
-#ifdef THREAD_PINNING_SUPPORTED
-    params.pin_to_hardware_threads = true;
-#endif // !THREAD_PINNING_SUPPORTED
-
-    auto action = [&]
-    (sysmakeshift::thread_squad::task_context ctx)
-    {
-        auto lock = std::unique_lock<std::mutex>(mutex);
-        threadIds.insert(std::this_thread::get_id());
-        threadIndices.insert(ctx.thread_index());
-    };
-
-    sysmakeshift::thread_squad(params).run(action);
-
-    CAPTURE(numThreads);
-
-#ifdef THREAD_PINNING_SUPPORTED
-    CHECK(threadIds.size() == static_cast<std::size_t>(numActualThreads));
-#endif // THREAD_PINNING_SUPPORTED
-    CHECK(threadIndices.size() == static_cast<std::size_t>(numActualThreads));
-}
-
-TEST_CASE("thread_squad can schedule multiple tasks")
+TEST_CASE("thread_squad")
 {
     GENERATE(range(0, 10)); // repetitions
 
     int numThreads = GENERATE(range(0, 10), 10, 48, 50);
+    CAPTURE(numThreads);
+
     unsigned numActualThreads = static_cast<unsigned>(numThreads);
     if (numActualThreads == 0)
     {
         numActualThreads = std::thread::hardware_concurrency();
     }
 
-    int numTasks = GENERATE(0, 1, 2, 5, 10, 20);
-
     std::mutex mutex;
-    std::unordered_map<std::thread::id, int> threadId_Count;
-    std::unordered_map<int, int> threadIndex_Count;
+    auto threadId_Count = std::unordered_map<std::thread::id, int>{ };
+    auto threadIndex_Count = std::unordered_map<int, int>{ };
+	int count = 0;
 
     auto params = sysmakeshift::thread_squad::params{
         /*.num_threads = */ numThreads
@@ -86,32 +46,59 @@ TEST_CASE("thread_squad can schedule multiple tasks")
         auto lock = std::unique_lock<std::mutex>(mutex);
         ++threadId_Count[std::this_thread::get_id()];
         ++threadIndex_Count[ctx.thread_index()];
+		++count;
     };
 
-    auto threadSquad = sysmakeshift::thread_squad(params);
-    for (int i = 0; i < numTasks; ++i)
+    SECTION("single task")
     {
-        threadSquad.run(action);
+        sysmakeshift::thread_squad(params).run(action);
+#ifdef THREAD_PINNING_SUPPORTED
+	    CHECK(threadId_Count.size() == static_cast<std::size_t>(numActualThreads));
+#endif // THREAD_PINNING_SUPPORTED
+    	CHECK(threadIndex_Count.size() == static_cast<std::size_t>(numActualThreads));
     }
 
-    CAPTURE(numThreads);
-    CAPTURE(numTasks);
+    SECTION("fixed number of tasks")
+    {
+        int numTasks = GENERATE(0, 1, 2, 5, 10, 20);
+        CAPTURE(numTasks);
 
-    if (numTasks != 0)
-    {
+	    auto threadSquad = sysmakeshift::thread_squad(params);
+    	for (int i = 0; i < numTasks; ++i)
+	    {
+    	    threadSquad.run(action);
+	    }
+
+	    if (numTasks != 0)
+    	{
 #ifdef THREAD_PINNING_SUPPORTED
-        CHECK(threadId_Count.size() == static_cast<std::size_t>(numActualThreads));
+	        CHECK(threadId_Count.size() == static_cast<std::size_t>(numActualThreads));
 #endif // THREAD_PINNING_SUPPORTED
-        CHECK(threadIndex_Count.size() == static_cast<std::size_t>(numActualThreads));
-    }
+    	    CHECK(threadIndex_Count.size() == static_cast<std::size_t>(numActualThreads));
+	    }
+
 #ifdef THREAD_PINNING_SUPPORTED
-    for (auto const& id_count : threadId_Count)
-    {
-        CHECK(id_count.second == numTasks);
-    }
+	    for (auto const& id_count : threadId_Count)
+    	{
+        	CHECK(id_count.second == numTasks);
+	    }
 #endif // THREAD_PINNING_SUPPORTED
-    for (auto const& index_count : threadIndex_Count)
+    	for (auto const& index_count : threadIndex_Count)
+	    {
+    	    CHECK(index_count.second == numTasks);
+	    }
+	}
+
+    SECTION("fixed number of tasks")
     {
-        CHECK(index_count.second == numTasks);
-    }
+	    auto threadSquad = sysmakeshift::thread_squad(params);
+		for (int i = 1; i <= int(numActualThreads); ++i)
+		{
+			CAPTURE(i);
+			threadSquad.run(action, i);
+		}
+
+		CHECK(count == numActualThreads * (numActualThreads + 1) / 2);
+	}
 }
+

--- a/test/test-thread_squad.cpp
+++ b/test/test-thread_squad.cpp
@@ -3,6 +3,7 @@
 
 #include <thread>
 #include <mutex>
+#include <algorithm>
 #include <unordered_set>
 #include <unordered_map>
 
@@ -27,6 +28,7 @@ TEST_CASE("thread_squad")
     {
         numActualThreads = std::thread::hardware_concurrency();
     }
+    unsigned numHardwareThreadsUsed = std::min(numActualThreads, std::thread::hardware_concurrency());
 
     std::mutex mutex;
     auto threadId_Count = std::unordered_map<std::thread::id, int>{ };
@@ -54,7 +56,7 @@ TEST_CASE("thread_squad")
         sysmakeshift::thread_squad(params).run(action);
         if (params.pin_to_hardware_threads)
         {
-            CHECK(threadId_Count.size() == static_cast<std::size_t>(numActualThreads));
+            CHECK(threadId_Count.size() == static_cast<std::size_t>(numHardwareThreadsUsed));
         }
         CHECK(threadIndex_Count.size() == static_cast<std::size_t>(numActualThreads));
     }
@@ -74,7 +76,7 @@ TEST_CASE("thread_squad")
         {
             if (params.pin_to_hardware_threads)
             {
-                CHECK(threadId_Count.size() == static_cast<std::size_t>(numActualThreads));
+                CHECK(threadId_Count.size() == static_cast<std::size_t>(numHardwareThreadsUsed));
             }
             CHECK(threadIndex_Count.size() == static_cast<std::size_t>(numActualThreads));
         }


### PR DESCRIPTION
Avoid redundant wakeups to further improve the efficiency of `thread_squad` (fewer syscalls).

Use thread-local senses instead of a global sense to properly support `thread_squad` undersubscription (task runs with concurrency lower than #threads).