### PR TITLE
Simplify and fix atomic waiting

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -61,6 +61,12 @@
             "inherits": [ "CI settings", "GCC presets", "ASan", "UBSan", "library debug checks" ]
         },
         {
+            "name": "ci-gcc-sanitize-thread",
+            "displayName": "GCC & TSan (for CI)",
+            "description": "Build with GCC and ThreadSanitizer (for Continuous Integration).",
+            "inherits": [ "CI settings", "GCC presets", "TSan" ]
+        },
+        {
             "name": "ci-clang",
             "displayName": "Clang (for CI)",
             "description": "Build with Clang (for Continuous Integration).",
@@ -73,6 +79,12 @@
             "inherits": [ "CI settings", "Clang presets", "libc++ for Clang", "ASan", "UBSan", "library debug checks" ]
         },
         {
+            "name": "ci-clang-sanitize-thread",
+            "displayName": "Clang & TSan (for CI)",
+            "description": "Build with Clang and ThreadSanitizer (for Continuous Integration).",
+            "inherits": [ "CI settings", "Clang presets", "libc++ for Clang", "TSan" ]
+        },
+        {
             "name": "ci-clang-libstdc++",
             "displayName": "Clang & libstdc++ (for CI)",
             "description": "Build with Clang (for Continuous Integration).",
@@ -83,6 +95,12 @@
             "displayName": "Clang & ASan & UBSan & libstdc++ & library debug checks (for CI)",
             "description": "Build with Clang and AddressSanitizer and UndefinedBehaviorSanitizer and libstdc++ and library debug checks (for Continuous Integration).",
             "inherits": [ "CI settings", "Clang presets", "libstdc++ for Clang", "ASan", "UBSan", "library debug checks" ]
+        },
+        {
+            "name": "ci-clang-libstdc++-sanitize-thread",
+            "displayName": "Clang & TSan & libstdc++ (for CI)",
+            "description": "Build with Clang and ThreadSanitizer and libstdc++ (for Continuous Integration).",
+            "inherits": [ "CI settings", "Clang presets", "libstdc++ for Clang", "TSan" ]
         }
     ]
 }

--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -72,6 +72,13 @@ jobs:
       tag: 'sanitize'
       cmakeConfigPreset: 'ci-gcc-sanitize'
 
+    - os: Linux
+      cxxCompiler: GCC
+      cxxCompilerVersions: [14]
+      platforms: [x64]
+      tag: 'sanitize-thread'
+      cmakeConfigPreset: 'ci-gcc-sanitize-thread'
+
     #- os: Linux
     #  cxxCompiler: Clang
     #  cxxCompilerVersions: [19]
@@ -83,6 +90,13 @@ jobs:
       platforms: [x64]
       tag: 'sanitize'
       cmakeConfigPreset: 'ci-clang-sanitize'
+
+    - os: Linux
+      cxxCompiler: Clang
+      cxxCompilerVersions: [19]
+      platforms: [x64]
+      tag: 'sanitize-thread'
+      cmakeConfigPreset: 'ci-clang-sanitize-thread'
 
     - os: Linux
       cxxCompiler: Clang

--- a/include/patton/detail/lazy-init.hpp
+++ b/include/patton/detail/lazy-init.hpp
@@ -14,17 +14,13 @@ T
 lazy_init(
     std::atomic<T>& value,
     T defaultValue,
-    F&& initFunc,
-    std::memory_order releaseOrder = std::memory_order_seq_cst)  // A release fence would be sufficient here, but we use sequential
-                                                                 // consistency by default to have other threads see the results of
-                                                                 // our hard work as soon as possible.
+    F&& initFunc)
 {
     T result = value.load(std::memory_order_relaxed);
     if (result == defaultValue)
     {
         result = initFunc();
-        value.store(result, std::memory_order_relaxed);
-        std::atomic_thread_fence(releaseOrder);
+        value.store(result, std::memory_order_release);
     }
     return result;
 }

--- a/include/patton/detail/thread_squad.hpp
+++ b/include/patton/detail/thread_squad.hpp
@@ -60,7 +60,7 @@ public:
 
     // We define our own value here instead of referring to `std::hardware_destructive_interference_size` because that can change
     // based on compiler flags and thus cause ABI breakage (which is why GCC issues a warning about it).
-static constexpr std::size_t destructive_interference_size = 64;
+static constexpr std::size_t destructive_interference_size = 1024;
 
 #ifdef _MSC_VER
 # pragma warning(push)

--- a/src/cpuinfo.cpp
+++ b/src/cpuinfo.cpp
@@ -228,15 +228,11 @@ init_cpu_info() noexcept
 #if defined(_WIN32) || defined(__linux__)
         int const* expectedPtr = nullptr;
         int const* desiredPtr = coreThreadIds.data();
-        if (cpu_info_value.core_thread_ids_ptr.compare_exchange_strong(expectedPtr, desiredPtr))
+        if (cpu_info_value.core_thread_ids_ptr.compare_exchange_strong(expectedPtr, desiredPtr, std::memory_order_release))
         {
             cpu_info_value.core_thread_ids = std::move(coreThreadIds);
         }
 #endif // defined(_WIN32) || defined(__linux__)
-
-            // A release fence would be sufficient here, but we use sequential consistency by default to have other threads see
-            // the results of our hard work as soon as possible.
-        std::atomic_thread_fence(std::memory_order_seq_cst);
     };
 
     auto physicalConcurrency = cpu_info_value.physical_concurrency.load(std::memory_order_relaxed);

--- a/src/thread_squad.cpp
+++ b/src/thread_squad.cpp
@@ -359,9 +359,13 @@ wait_and_load(
 {
     if (waitMode != wait_mode::spin_wait || !detail::wait_equal_exponential_backoff(a, oldValue))
     {
-        a.wait(oldValue, std::memory_order_relaxed);
+        a.wait(oldValue, std::memory_order_acquire);
+        return a.load(std::memory_order_relaxed);
     }
-    return a.load(std::memory_order_acquire);
+    else
+    {
+        return a.load(std::memory_order_acquire);
+    }
 }
 
 template <typename T>

--- a/src/thread_squad.cpp
+++ b/src/thread_squad.cpp
@@ -708,7 +708,7 @@ private:
     static constexpr int treeBreadth = 8;
 
         // synchronization data
-    aligned_buffer<thread_data, cache_line_alignment> threadData_;
+    aligned_buffer<thread_data, page_alignment> threadData_;
     wait_mode waitMode_;
 
         // task-specific data

--- a/src/thread_squad.cpp
+++ b/src/thread_squad.cpp
@@ -369,8 +369,6 @@ T
 toggle_and_notify(
     std::atomic<T>& a) noexcept
 {
-    std::atomic_thread_fence(std::memory_order_release);
-
     T oldValue = a.load(std::memory_order_relaxed);
     T newValue = 1 ^ oldValue;
     a.store(newValue, std::memory_order_release);


### PR DESCRIPTION
Change flag updating logic such that ABA problems become impossible: for every atomic, there is exactly one thread – the alerting thread – which may set it (to 1), and another thread – the waiting thread – which may reset it (to 0).

Also refine alignment parameters to improve performance and add TSan runs to CI.